### PR TITLE
Don't get weights for distances the algorithm can't handle (>2.0)

### DIFF
--- a/CfL_Prediction.glsl
+++ b/CfL_Prediction.glsl
@@ -48,7 +48,7 @@ vec4 hook() {
 
 float comp_wd(vec2 distance) {
     float d2 = min(pow(length(distance), 2.0), 4.0);
-    return (25.0 / 16.0 * pow(2.0 / 5.0 * d2 - 1.0, 2.0) - (25.0 / 16.0 - 1.0)) * pow(1.0 / 4.0 * d2 - 1.0, 2.0);
+    return return d2 < 2.0 ? (25.0 / 16.0 * pow(2.0 / 5.0 * d2 - 1.0, 2.0) - (25.0 / 16.0 - 1.0)) * pow(1.0 / 4.0 * d2 - 1.0, 2.0) : 0.0;
 }
 
 vec4 hook() {

--- a/CfL_Prediction.glsl
+++ b/CfL_Prediction.glsl
@@ -48,7 +48,7 @@ vec4 hook() {
 
 float comp_wd(vec2 distance) {
     float d2 = min(pow(length(distance), 2.0), 4.0);
-    return return d2 < 2.0 ? (25.0 / 16.0 * pow(2.0 / 5.0 * d2 - 1.0, 2.0) - (25.0 / 16.0 - 1.0)) * pow(1.0 / 4.0 * d2 - 1.0, 2.0) : 0.0;
+    return d2 < 2.0 ? (25.0 / 16.0 * pow(2.0 / 5.0 * d2 - 1.0, 2.0) - (25.0 / 16.0 - 1.0)) * pow(1.0 / 4.0 * d2 - 1.0, 2.0) : 0.0;
 }
 
 vec4 hook() {


### PR DESCRIPTION
Fixes https://github.com/Artoriuz/glsl-chroma-from-luma-prediction/issues/5 and other artifacts like borders disappearing ect. , https://github.com/Artoriuz/glsl-chroma-from-luma-prediction/issues/10 (I think the only reason was because it wasn't respecting it).

Downside is scaling of text ect. doesn't look as great, you'd need to consider switching to an algorithm that can handle a radius >2.0 (I've had pretty good results with Garamond), even Hamming seems better if you need speed and sharpness loss is acceptable.