### PR TITLE
don't run smoothing when chroma wasn't upscaled

### DIFF
--- a/CfL_Prediction.glsl
+++ b/CfL_Prediction.glsl
@@ -327,6 +327,7 @@ vec4 hook() {
 //!HOOK CHROMA
 //!BIND CHROMA
 //!BIND LUMA
+//!BIND LUMA_LR
 //!DESC Chroma From Luma Prediction (Smoothing Chroma)
 
 float comp_w(vec2 spatial_distance, float intensity_distance) {


### PR DESCRIPTION
Fixes: https://github.com/Artoriuz/glsl-chroma-from-luma-prediction/issues/17